### PR TITLE
Allow compatible browser extensions to override default vendor

### DIFF
--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -14,8 +14,7 @@ type ConnexSigner = ReturnType<typeof ConnexWalletBuddy.create>
 declare global {
     interface Window {
       vechain?: {
-        isVeWorld?: boolean
-        getSigner: (genesisId: string) => ConnexSigner
+        getSigner?: (genesisId: string) => ConnexSigner
       }
     }
   }
@@ -60,7 +59,7 @@ export class DriverVendorOnly implements Connex.Driver {
     }
 
     getSigner(): Promise<ConnexSigner> {
-        if (!this.noExtension && window.vechain?.isVeWorld) {
+        if (!this.noExtension && window.vechain?.getSigner) {
             if (!this.extensionSigner){
                 //Initiate the signer on the first call
                 this.extensionSigner = window.vechain.getSigner(this.genesisId)

--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -14,7 +14,7 @@ type ConnexSigner = ReturnType<typeof ConnexWalletBuddy.create>
 declare global {
     interface Window {
       vechain?: {
-        getSigner?: (genesisId: string) => ConnexSigner
+        getConnexSigner?: (genesisId: string) => ConnexSigner
       }
     }
   }
@@ -59,10 +59,10 @@ export class DriverVendorOnly implements Connex.Driver {
     }
 
     private getSigner(): Promise<ConnexSigner> {
-        if (!this.noExtension && window.vechain?.getSigner) {
+        if (!this.noExtension && window.vechain?.getConnexSigner) {
             if (!this.extensionSigner){
                 //Initiate the signer on the first call
-                this.extensionSigner = window.vechain.getSigner(this.genesisId)
+                this.extensionSigner = window.vechain.getConnexSigner(this.genesisId)
             }
             return Promise.resolve(this.extensionSigner as ConnexSigner)
         }

--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -58,7 +58,7 @@ export class DriverVendorOnly implements Connex.Driver {
         return this.getSigner().then(s => s.signCert(msg, options))
     }
 
-    getSigner(): Promise<ConnexSigner> {
+    private getSigner(): Promise<ConnexSigner> {
         if (!this.noExtension && window.vechain?.getSigner) {
             if (!this.extensionSigner){
                 //Initiate the signer on the first call

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -72,6 +72,9 @@ export type Options = {
 
     /** the flag to disable the compatibility with connex1 environment */
     noV1Compat?: boolean
+
+    /** the flag to disable the vechain browser extension */
+    noExtension?: boolean
 }
 
 /** Connex class */
@@ -97,7 +100,7 @@ class ConnexClass implements Connex {
             } catch { /**/ }
         }
 
-        const driver = createFull(opts.node, genesis)
+        const driver = createFull(opts, genesis)
         const framework = new Framework(driver)
         return {
             get thor() { return framework.thor },


### PR DESCRIPTION
These changes will enable compatible VeChain browser extensions to sign and send transactions