### PR TITLE
Fix iOS signing windows not opening

### DIFF
--- a/packages/wallet-buddy/src/helper.ts
+++ b/packages/wallet-buddy/src/helper.ts
@@ -5,7 +5,7 @@ export const browser = detect()
 
 const LITE_WALLET_URL = 'https://lite.sync.vecha.in/'
 
-function openLiteWallet(src: string): Window | null {
+function openLiteWallet(src: string): void {
     const options = (() => {
         switch (browser && browser.os) {
             case 'iOS':
@@ -20,10 +20,12 @@ function openLiteWallet(src: string): Window | null {
         }
     })()
 
-    return window.open(
-        new URL(`#/sign?src=${encodeURIComponent(src)}`, LITE_WALLET_URL).href,
-        options.target,
-        options.features)
+    setTimeout(() => {
+        window.open(
+            new URL(`#/sign?src=${encodeURIComponent(src)}`, LITE_WALLET_URL).href,
+            options.target,
+            options.features)
+    })
 }
 
 const getHiddenIframe = (() => {


### PR DESCRIPTION
On iOS mobile devices transactions dialogs are not opened within async functions.

- `window.open` will silently do nothing and users do not get an error message
- https://stackoverflow.com/a/70463940/344570 supposes a fix by wrapping it into with `setTimeout` (_because only the main thread seems to be allowed to open new windows_)
- I have tested this fix on iOS successfully.
- because the change to use `setTimeout` does not provide instant return of the window, the return was changed to `void` after carefully checking the code for any usage of the return value and none was found
- I don't see potential problems by making this behavior default but have not tested it on all platforms
- Here is an example page that shows the problem and that the solution works:
    - https://x2wx70.csb.app