### PR TITLE
adding the connex driver interface to the types library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ typings/
 
 dist/
 esm/
+.idea

--- a/packages/types/driver.d.ts
+++ b/packages/types/driver.d.ts
@@ -1,0 +1,76 @@
+/** Connex driver interface */
+declare namespace Connex {
+    interface Driver {
+        readonly genesis: Thor.Block
+        /** current known head */
+        readonly head: Thor.Status['head']
+
+        /**
+         * poll new head
+         * rejected only when driver closed
+         */
+        pollHead(): Promise<Thor.Status['head']>
+
+        getBlock(revision: string | number): Promise<Thor.Block | null>
+        getTransaction(id: string, allowPending: boolean): Promise<Thor.Transaction | null>
+        getReceipt(id: string): Promise<Thor.Transaction.Receipt | null>
+
+        getAccount(addr: string, revision: string): Promise<Thor.Account>
+        getCode(addr: string, revision: string): Promise<Thor.Account.Code>
+        getStorage(addr: string, key: string, revision: string): Promise<Thor.Account.Storage>
+
+        explain(arg: Driver.ExplainArg, revision: string, cacheHints?: string[]): Promise<VM.Output[]>
+
+        filterEventLogs(arg: Driver.FilterEventLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'event'>[]>
+        filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
+
+        // vendor methods
+        signTx(msg: Vendor.TxMessage, options: Driver.TxOptions): Promise<Vendor.TxResponse>
+        signCert(msg: Vendor.CertMessage, option: Driver.CertOptions): Promise<Vendor.CertResponse>
+    }
+
+    namespace Driver {
+        type ExplainArg = {
+            clauses: Thor.Transaction['clauses'],
+            caller?: string
+            gas?: number
+            gasPrice?: string
+        }
+
+        type FilterEventLogsArg = {
+            range: Thor.Filter.Range
+            options: {
+                offset: number
+                limit: number
+            }
+            criteriaSet: Thor.Filter.Criteria<'event'>[]
+            order: 'asc' | 'desc'
+        }
+
+        type FilterTransferLogsArg = {
+            range: Thor.Filter.Range
+            options: {
+                offset: number
+                limit: number
+            }
+            criteriaSet: Thor.Filter.Criteria<'transfer'>[]
+            order: 'asc' | 'desc'
+        }
+
+        type TxOptions = {
+            signer?: string
+            gas?: number
+            dependsOn?: string
+            link?: string
+            comment?: string
+            delegator?: { url: string, signer?: string }
+            onAccepted?: () => void
+        }
+
+        type CertOptions = {
+            signer?: string
+            link?: string
+            onAccepted?: () => void
+        }
+    }
+}

--- a/packages/types/signer.d.ts
+++ b/packages/types/signer.d.ts
@@ -1,0 +1,7 @@
+/** Connex driver interface */
+declare namespace Connex {
+    interface Signer {
+        signTx(msg: Connex.Vendor.TxMessage, options: Connex.Driver.TxOptions): Promise<Connex.Vendor.TxResponse>
+        signCert(msg: Connex.Vendor.CertMessage, option: Connex.Driver.CertOptions): Promise<Connex.Vendor.CertResponse>
+    }
+}


### PR DESCRIPTION
Creating interfaces to pass custom signers into the Connex instance.
This PR will allow other libraries to implement the connex signer without installing `@vechain/connex` as a dependency