### PR TITLE
add signer type for custom signers

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -5,6 +5,7 @@
 /// <reference path="block.d.ts" />
 /// <reference path="tx.d.ts" />
 /// <reference path="filter.d.ts" />
+/// <reference path="signer.d.ts" />
 
 /** The VeChain Connex interface */
 declare interface Connex {

--- a/packages/types/signer.d.ts
+++ b/packages/types/signer.d.ts
@@ -1,0 +1,34 @@
+declare namespace Connex {
+    /** 
+     * signer defines the interfaces needs be to implemented of a wallet. 
+     * it is the driver of vendor, exposing the interface for any possible 
+     * wallet implementing a custom signer
+    */
+    interface Signer {
+        signTx(msg: Vendor.TxMessage, options: Signer.TxOptions): Promise<Vendor.TxResponse>
+        signCert(msg: Vendor.CertMessage, options: Signer.CertOptions): Promise<Vendor.CertResponse>
+    }
+
+    namespace Signer {
+        type TxOptions = {
+            signer?: string;
+            gas?: number;
+            dependsOn?: string;
+            link?: string;
+            comment?: string;
+            delegator?: {
+                url: string;
+                signer?: string;
+            };
+            onAccepted?: () => void;
+        };
+        type CertOptions = {
+            signer?: string;
+            link?: string;
+            onAccepted?: () => void;
+        };
+    }
+
+    // NewSigner creates a singer with genesis id.
+    type NewSigner = (genesisId: string)=> Promise<Signer>
+}


### PR DESCRIPTION
Inspired by vechain/connex#146, make it possible for veworld mobile creating a custom signer library.