### PR TITLE
Fix lint issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "root",
   "private": true,
   "scripts": {
-    "lint": "npx eslint ."
+    "lint": "npx eslint .",
+
+    "install:connex": "cd packages/connex && npm install",
+    "install:driver": "cd packages/driver && npm install",
+    "install:framework": "cd packages/framework && npm install",
+    "install:repl": "cd packages/repl && npm install",
+    "install:wallet-buddy": "cd packages/wallet-buddy && npm install",
+    "postinstall": "npm run install:connex && npm run install:driver && npm run install:framework && npm run install:repl && npm run install:wallet-buddy"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "root",
-  "private": true,
-  "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.3.0",
-    "@typescript-eslint/parser": "^4.3.0",
-    "eslint": "^7.10.0",
-    "lerna": "^3.20.2",
-    "ts-node": "^8.8.1",
-    "typescript": "^4.0.2"
-  }
+    "name": "root",
+    "private": true,
+    "scripts": {
+        "lint": "npx eslint ."
+    },
+    "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.3.0",
+        "@typescript-eslint/parser": "^4.3.0",
+        "eslint": "^7.10.0",
+        "lerna": "^3.20.2",
+        "ts-node": "^8.8.1",
+        "typescript": "^4.0.2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "root",
-    "private": true,
-    "scripts": {
-        "lint": "npx eslint ."
-    },
-    "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.3.0",
-        "@typescript-eslint/parser": "^4.3.0",
-        "eslint": "^7.10.0",
-        "lerna": "^3.20.2",
-        "ts-node": "^8.8.1",
-        "typescript": "^4.0.2"
-    }
+  "name": "root",
+  "private": true,
+  "scripts": {
+    "lint": "npx eslint ."
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.3.0",
+    "@typescript-eslint/parser": "^4.3.0",
+    "eslint": "^7.10.0",
+    "lerna": "^3.20.2",
+    "ts-node": "^8.8.1",
+    "typescript": "^4.0.2"
+  }
 }

--- a/packages/connex/package.json
+++ b/packages/connex/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/ esm/ && ../../node_modules/.bin/tsc -p . && webpack",
-    "lint": "../../node_modules/.bin/tslint -p .",
+    "lint": "npx eslint src/**/*.ts",
     "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/ esm/ && ../../node_modules/.bin/tsc -d -p . && ../../node_modules/.bin/tsc --module esnext --outDir 'esm' -p .",
-    "lint": "../../node_modules/.bin/tslint -p .",
+    "lint": "npx eslint src/**/*.ts",
     "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/ esm/ && ../../node_modules/.bin/tsc -d -p . && ../../node_modules/.bin/tsc --module esnext --outDir 'esm' -p .",
-    "lint": "../../node_modules/.bin/tslint -p .",
+    "lint": "npx eslint src/**/*.ts",
     "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/;../../node_modules/.bin/tsc -p .;cp src/index.js dist/",
-    "lint": "../../node_modules/.bin/tslint -p .",
+    "lint": "npx eslint src/**/*.ts",
     "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/wallet-buddy/package.json
+++ b/packages/wallet-buddy/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "rm -rf dist/ esm/ && ../../node_modules/.bin/tsc -p . && webpack",
-    "lint": "../../node_modules/.bin/tslint -p .",
+    "lint": "npx eslint src/**/*.ts",
     "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Hello,
I hope you're doing well.
Previously, the `lint` script in the `package.json` was using TSLint to check the TypeScript files (and was not working).
We are now using ESLint command instead.
This is a positive change since ESLint is widely adopted and provides more extensive configuration options and plugin support. It will help maintain a consistent and clean codebase.
