### PR TITLE
exporting useful functions

### DIFF
--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -11,6 +11,7 @@ const BUDDY_LIB_NAME = 'ConnexWalletBuddy'
 type ConnexSigner = Pick<Connex.Driver, 'signTx' | 'signCert'>
 export type ExtensionSigner = {
     newConnexSigner: (genesisId: string) => ConnexSigner
+    newConnexVendor: (genesisId: string) => Connex.Vendor
 }
 
 /** the driver implements vendor methods only */

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -3,7 +3,7 @@ import { genesisBlocks } from './config'
 import { compat1, Connex1 } from './compat'
 import { createFull, DriverVendorOnly, ExtensionSigner } from './driver'
 import { newVendor, newThor } from '@vechain/connex-framework'
-import { DriverNoVendor, SimpleNet } from '@vechain/connex-driver'
+import { DriverNoVendor, SimpleNet, Driver } from '@vechain/connex-driver'
 
 declare global {
     interface Window {
@@ -134,6 +134,7 @@ export {
     ConnexClass as Connex, 
     VendorClass as Vendor,
     Sync2Vendor,
+    Driver,
     DriverVendorOnly,
     DriverNoVendor,
     SimpleNet,

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -125,4 +125,8 @@ class ConnexClass implements Connex {
 }
 
 export default ConnexClass
-export { ConnexClass as Connex }
+
+export { 
+    ConnexClass as Connex, 
+    VendorClass as Vendor 
+}

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -139,4 +139,5 @@ export {
     SimpleNet,
     newVendor,
     newThor,
+    genesisBlocks,
 }

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -2,7 +2,8 @@ import { Framework } from '@vechain/connex-framework'
 import { genesisBlocks } from './config'
 import { compat1, Connex1 } from './compat'
 import { createFull, DriverVendorOnly, ExtensionSigner } from './driver'
-import { newVendor } from '@vechain/connex-framework'
+import { newVendor, newThor } from '@vechain/connex-framework'
+import { DriverNoVendor, SimpleNet } from '@vechain/connex-driver'
 
 declare global {
     interface Window {
@@ -124,9 +125,18 @@ class ConnexClass implements Connex {
     }
 }
 
+const Sync2Vendor = (genesisId?: 'main' | 'test' | string): Connex.Vendor => 
+    new VendorClass(genesisId, { noV1Compat: true, noExtension: true })
+
 export default ConnexClass
 
 export { 
     ConnexClass as Connex, 
-    VendorClass as Vendor 
+    VendorClass as Vendor,
+    Sync2Vendor,
+    DriverVendorOnly,
+    DriverNoVendor,
+    SimpleNet,
+    newVendor,
+    newThor,
 }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -32,4 +32,4 @@ export class Framework implements Connex {
     }
 }
 
-export { newVendor }
+export { newVendor, newThor }


### PR DESCRIPTION
exporting the `VendorClass` so we can construct a Sync2 `Connex.Vendor` without creating the full connex with driver etc.