### PR TITLE
Dev

### DIFF
--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -10,7 +10,7 @@ export class LazyDriver implements Connex.Driver {
     
     private get noVendor(): DriverNoVendor { 
         if (!this._driver) {
-            throw new Error('driver no vendor is not ready')
+            throw new Error('thor driver is not ready')
         }
         return this._driver
     }

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -1,4 +1,4 @@
-import { Framework } from '@vechain/connex-framework'
+import { Framework, newVendor } from '@vechain/connex-framework'
 import { genesisBlocks } from './config'
 import { createFull, createNoVendor, LazyDriver } from './driver'
 import { Connex1, createSync, createSync2 } from './signer'
@@ -111,10 +111,11 @@ class VendorClass implements Connex.Vendor {
         const newSigner = normalizeSigner(genesisId,signer)
 
         const driver = new LazyDriver(newSigner(genesisId))
-        const framework = new Framework(driver)
+        const vendor = newVendor(driver)
+        
         return {
             get sign() {
-                return framework.vendor.sign.bind(framework.vendor)
+                return vendor.sign.bind(vendor)
             }
         }
     }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -95,13 +95,13 @@ export class DriverNoVendor implements Connex.Driver {
         msg: Connex.Vendor.TxMessage,
         options: Connex.Signer.TxOptions
     ): Promise<Connex.Vendor.TxResponse> {
-        throw new Error('not implemented')
+        throw new Error('signer not implemented')
     }
     public signCert(
         msg: Connex.Vendor.CertMessage,
         options: Connex.Signer.CertOptions
     ): Promise<Connex.Vendor.CertResponse> {
-        throw new Error('not implemented')
+        throw new Error('signer not implemented')
     }
     //////
     protected mergeRequest(req: () => Promise<any>, ...keyParts: any[]) {


### PR DESCRIPTION
commit e93e4f654bde16a17f7d7795ea99da2814664386 is a regression, `newVendor` existed for a certain reason :-<, new Framework will access thor related fileds in driver.