### PR TITLE
feat: `fees` endpoints support

### DIFF
--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -55,8 +55,8 @@ export class LazyDriver implements Connex.Driver {
         return this.noVendor.filterTransferLogs(arg)
     }
 
-    getFees(newestBlock: string | number, blockCount: number): Promise<Connex.Thor.Fees | null> {
-        return this.noVendor.getFees(newestBlock, blockCount)
+    getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees | null> {
+        return this.noVendor.getFees(newestBlock, blockCount, rewardPercentiles)
     }
 
     getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {

--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -55,11 +55,11 @@ export class LazyDriver implements Connex.Driver {
         return this.noVendor.filterTransferLogs(arg)
     }
 
-    getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees | null> {
+    getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees> {
         return this.noVendor.getFees(newestBlock, blockCount, rewardPercentiles)
     }
 
-    getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {
+    getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion> {
         return this.noVendor.getPriorityFeeSuggestion()
     }
 

--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -32,28 +32,36 @@ export class LazyDriver implements Connex.Driver {
     }
     getTransaction(id: string, allowPending: boolean): Promise<Connex.Thor.Transaction | null> { 
         return this.noVendor.getTransaction(id, allowPending)
-     }
+    }
     getReceipt(id: string): Promise<Connex.Thor.Transaction.Receipt | null> { 
         return this.noVendor.getReceipt(id)
-     }
+    }
     getAccount(addr: string, revision: string): Promise<Connex.Thor.Account> { 
         return this.noVendor.getAccount(addr, revision)
-     }
+    }
     getCode(addr: string, revision: string): Promise<Connex.Thor.Account.Code> {
         return this.noVendor.getCode(addr, revision)
     }
     getStorage(addr: string, key: string, revision: string): Promise<Connex.Thor.Account.Storage> { 
         return this.noVendor.getStorage(addr, key, revision)
-     }
+    }
     explain(arg: Connex.Driver.ExplainArg, revision: string, cacheHints?: string[]): Promise<Connex.VM.Output[]> { 
         return this.noVendor.explain(arg, revision, cacheHints)
-     }
+    }
     filterEventLogs(arg: Connex.Driver.FilterEventLogsArg): Promise<Connex.Thor.Filter.Row<'event'>[]> { 
         return this.noVendor.filterEventLogs(arg)
-     }
+    }
     filterTransferLogs(arg: Connex.Driver.FilterTransferLogsArg): Promise<Connex.Thor.Filter.Row<'transfer'>[]> { 
         return this.noVendor.filterTransferLogs(arg)
-     }
+    }
+
+    getFees(newestBlock: string | number, blockCount: number): Promise<Connex.Thor.Fees | null> {
+        return this.noVendor.getFees(newestBlock, blockCount)
+    }
+
+    getPriorityFeeSuggestion(): Promise<string | null> {
+        return this.noVendor.getPriorityFeeSuggestion()
+    }
 
     async signTx(msg: Connex.Vendor.TxMessage, options: Connex.Signer.TxOptions): Promise<Connex.Vendor.TxResponse> {
         return this.signer.then(b => b.signTx(msg, options))

--- a/packages/connex/src/driver.ts
+++ b/packages/connex/src/driver.ts
@@ -59,7 +59,7 @@ export class LazyDriver implements Connex.Driver {
         return this.noVendor.getFees(newestBlock, blockCount)
     }
 
-    getPriorityFeeSuggestion(): Promise<string | null> {
+    getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {
         return this.noVendor.getPriorityFeeSuggestion()
     }
 

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -84,7 +84,8 @@ class ThorClass implements Connex.Thor {
     filter !: Connex.Thor['filter']
     explain !: Connex.Thor['explain']
     fees !: Connex.Thor['fees']
-
+    priorityFeeSuggestion !: Connex.Thor['priorityFeeSuggestion']
+    
     constructor(opts: Omit<Options, 'signer'>) {
         const genesis = normalizeNetwork(opts.network)
 
@@ -100,7 +101,8 @@ class ThorClass implements Connex.Thor {
             get transaction() { return framework.thor.transaction.bind(framework.thor) },
             get filter() { return framework.thor.filter.bind(framework.thor) },
             get explain() { return framework.thor.explain.bind(framework.thor) },
-            get fees() { return framework.thor.fees.bind(framework.thor) }
+            get fees() { return framework.thor.fees.bind(framework.thor) },
+            get priorityFeeSuggestion() { return framework.thor.priorityFeeSuggestion.bind(framework.thor) }
         }
     }
 }

--- a/packages/connex/src/index.ts
+++ b/packages/connex/src/index.ts
@@ -83,6 +83,7 @@ class ThorClass implements Connex.Thor {
     transaction !: Connex.Thor['transaction']
     filter !: Connex.Thor['filter']
     explain !: Connex.Thor['explain']
+    fees !: Connex.Thor['fees']
 
     constructor(opts: Omit<Options, 'signer'>) {
         const genesis = normalizeNetwork(opts.network)
@@ -98,7 +99,8 @@ class ThorClass implements Connex.Thor {
             get block() { return framework.thor.block.bind(framework.thor) },
             get transaction() { return framework.thor.transaction.bind(framework.thor) },
             get filter() { return framework.thor.filter.bind(framework.thor) },
-            get explain() { return framework.thor.explain.bind(framework.thor) }
+            get explain() { return framework.thor.explain.bind(framework.thor) },
+            get fees() { return framework.thor.fees.bind(framework.thor) }
         }
     }
 }

--- a/packages/driver/src/cache.ts
+++ b/packages/driver/src/cache.ts
@@ -19,7 +19,7 @@ export class Cache {
         blocks: new LRU<string | number, Connex.Thor.Block>(256),
         txs: new LRU<string, Connex.Thor.Transaction>(512),
         receipts: new LRU<string, Connex.Thor.Transaction.Receipt>(512),
-        fees: new LRU<string, Connex.Thor.Fees>(256)
+        fees: new LRU<string, Connex.Thor.Fees>(512)
     }
     private readonly window: Slot[] = []
 

--- a/packages/driver/src/cache.ts
+++ b/packages/driver/src/cache.ts
@@ -96,9 +96,13 @@ export class Cache {
     public async getFees(
         newestBlock: string | number,
         blockCount: number,
+        rewardPercentiles: number[],
         fetch: () => Promise<Connex.Thor.Fees>
     ): Promise<Connex.Thor.Fees> {
         let key = `${newestBlock}-${blockCount}`
+        if (rewardPercentiles.length > 0) {
+            key = `${key}-${rewardPercentiles.join(',')}`
+        }
         const cachedRange = this.irreversible.fees.get(key)
         if (cachedRange) {
             return cachedRange
@@ -111,6 +115,9 @@ export class Cache {
             // i.e. backtrace limit is 2, we have 7 blocks, we request 4 from 'best'
             if (range.baseFeePerGas.length < blockCount) {
                 key = `${newestBlock}-${blockCount - range.baseFeePerGas.length}`
+                if (rewardPercentiles.length > 0) {
+                    key = `${key}-${rewardPercentiles.join(',')}`
+                }
             }
             this.irreversible.fees.set(key, range)
         }

--- a/packages/driver/src/cache.ts
+++ b/packages/driver/src/cache.ts
@@ -108,6 +108,7 @@ export class Cache {
         if (range && range.baseFeePerGas.length > 0) {
             // Key change for the case where we are starting a network with less blocks than the blockCount
             // Also this could happen for cases including the backtrace limit
+            // i.e. backtrace limit is 2, we have 7 blocks, we request 4 from 'best'
             if (range.baseFeePerGas.length < blockCount) {
                 key = `${newestBlock}-${blockCount - range.baseFeePerGas.length}`
             }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -1,8 +1,8 @@
-import { Net } from './interfaces'
-import { PromInt, InterruptedError } from './promint'
-import { Cache } from './cache'
 import { blake2b256 } from 'thor-devkit'
+import { Cache } from './cache'
 import { sleep } from './common'
+import { Net } from './interfaces'
+import { InterruptedError, PromInt } from './promint'
 
 /** class implements Connex.Driver leaves out Vendor related methods */
 export class DriverNoVendor implements Connex.Driver {
@@ -51,6 +51,21 @@ export class DriverNoVendor implements Connex.Driver {
         return this.cache.getBlock(revision, () =>
             this.httpGet(`blocks/${revision}`))
     }
+
+    public getFees(newestBlock: string | number, blockCount: number): Promise<Connex.Thor.Fees | null> {
+        return this.getBlock(newestBlock)
+            .then(block => {
+                if (!block) {
+                    return null
+                }
+                return this.cache.getFees(block.id, blockCount, () =>
+                    this.httpGet('fees/history', { 
+                        newestBlock: block.id,
+                        blockCount: blockCount.toString()
+                    }))
+            })
+    }
+
     public getTransaction(id: string, allowPending: boolean): Promise<Connex.Thor.Transaction | null> {
         return this.cache.getTx(id, () => {
             const query: Record<string, string> = { head: this.head.id }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -53,17 +53,11 @@ export class DriverNoVendor implements Connex.Driver {
     }
 
     public getFees(newestBlock: string | number, blockCount: number): Promise<Connex.Thor.Fees | null> {
-        return this.getBlock(newestBlock)
-            .then(block => {
-                if (!block) {
-                    return null
-                }
-                return this.cache.getFees(block.id, blockCount, () =>
-                    this.httpGet('fees/history', { 
-                        newestBlock: block.id,
-                        blockCount: blockCount.toString()
-                    }))
-            })
+        return this.cache.getFees(newestBlock, blockCount, () =>
+            this.httpGet('fees/history', { 
+                newestBlock: newestBlock.toString(),
+                blockCount: blockCount.toString()
+            }))
     }
 
     public getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -66,7 +66,7 @@ export class DriverNoVendor implements Connex.Driver {
             })
     }
 
-    public getPriorityFeeSuggestion(): Promise<string | null> {
+    public getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {
         // No cache since we do not have a key for it
         return this.httpGet('fees/priority')
     }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -52,7 +52,7 @@ export class DriverNoVendor implements Connex.Driver {
             this.httpGet(`blocks/${revision}`))
     }
 
-    public getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees | null> {
+    public getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees> {
         return this.cache.getFees(newestBlock, blockCount, rewardPercentiles || [], () => {
             const params: Record<string, string> = {
                 newestBlock: newestBlock.toString(),
@@ -65,7 +65,7 @@ export class DriverNoVendor implements Connex.Driver {
         })
     }
 
-    public getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {
+    public getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion> {
         // No cache since we do not have a key for it
         return this.httpGet('fees/priority')
     }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -66,6 +66,11 @@ export class DriverNoVendor implements Connex.Driver {
             })
     }
 
+    public getPriorityFeeSuggestion(): Promise<string | null> {
+        // No cache since we do not have a key for it
+        return this.httpGet('fees/priority')
+    }
+
     public getTransaction(id: string, allowPending: boolean): Promise<Connex.Thor.Transaction | null> {
         return this.cache.getTx(id, () => {
             const query: Record<string, string> = { head: this.head.id }

--- a/packages/driver/src/driver-no-vendor.ts
+++ b/packages/driver/src/driver-no-vendor.ts
@@ -52,12 +52,17 @@ export class DriverNoVendor implements Connex.Driver {
             this.httpGet(`blocks/${revision}`))
     }
 
-    public getFees(newestBlock: string | number, blockCount: number): Promise<Connex.Thor.Fees | null> {
-        return this.cache.getFees(newestBlock, blockCount, () =>
-            this.httpGet('fees/history', { 
+    public getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Connex.Thor.Fees | null> {
+        return this.cache.getFees(newestBlock, blockCount, rewardPercentiles || [], () => {
+            const params: Record<string, string> = {
                 newestBlock: newestBlock.toString(),
                 blockCount: blockCount.toString()
-            }))
+            }
+            if (rewardPercentiles && rewardPercentiles.length > 0) {
+                params.rewardPercentiles = rewardPercentiles.join(',')
+            }
+            return this.httpGet('fees/history', params)
+        })
     }
 
     public getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null> {

--- a/packages/framework/src/driver-guard.ts
+++ b/packages/framework/src/driver-guard.ts
@@ -92,8 +92,8 @@ export function newDriverGuard(
                     signature: v => R.isHexBytes(v, 65) ? '' : 'expected 65 bytes'
                 }, 'signCert()'))
         },
-        getFees(newestBlock, blockCount) {
-            return driver.getFees(newestBlock, blockCount)
+        getFees(newestBlock, blockCount, rewardPercentiles) {
+            return driver.getFees(newestBlock, blockCount, rewardPercentiles)
                 .then(f => f ? test(f, feeScheme, 'getFees()') : f)
         },
         getPriorityFeeSuggestion() {
@@ -234,7 +234,10 @@ const vmOutputScheme: V.Scheme<Connex.VM.Output> = {
 const feeScheme: V.Scheme<Connex.Thor.Fees> = {
     oldestBlock: R.bytes32,
     baseFeePerGas: [R.hexString],
-    gasUsedRatio: [R.uint64],
+    gasUsedRatio: [v => {
+        const num = Number(v);
+        return !isNaN(num) && num >= 0 && num <= 1 ? '' : 'expected a number between 0 and 1';
+    }],
     reward: V.optional([[R.hexString]])
 }
 

--- a/packages/framework/src/driver-guard.ts
+++ b/packages/framework/src/driver-guard.ts
@@ -95,6 +95,10 @@ export function newDriverGuard(
         getFees(newestBlock, blockCount) {
             return driver.getFees(newestBlock, blockCount)
                 .then(f => f ? test(f, feeScheme, 'getFees()') : f)
+        },
+        getPriorityFeeSuggestion() {
+            return driver.getPriorityFeeSuggestion()
+                .then(r => test(r, R.hexString, 'getPriorityFeeSuggestion()'))
         }
     }
 }

--- a/packages/framework/src/driver-guard.ts
+++ b/packages/framework/src/driver-guard.ts
@@ -232,6 +232,7 @@ const vmOutputScheme: V.Scheme<Connex.VM.Output> = {
 }
 
 const feeScheme: V.Scheme<Connex.Thor.Fees> = {
+    oldestBlock: R.bytes32,
     baseFeePerGas: [R.hexString],
     gasUsedRatio: [R.uint64],
     reward: V.optional([[R.hexString]])

--- a/packages/framework/src/driver-guard.ts
+++ b/packages/framework/src/driver-guard.ts
@@ -98,7 +98,7 @@ export function newDriverGuard(
         },
         getPriorityFeeSuggestion() {
             return driver.getPriorityFeeSuggestion()
-                .then(r => test(r, R.hexString, 'getPriorityFeeSuggestion()'))
+                .then(r => r ? test(r, priorityFeeSuggestionScheme, 'getPriorityFeeSuggestion()') : r)
         }
     }
 }
@@ -234,5 +234,9 @@ const vmOutputScheme: V.Scheme<Connex.VM.Output> = {
 const feeScheme: V.Scheme<Connex.Thor.Fees> = {
     baseFeePerGas: [R.hexString],
     gasUsedRatio: [R.uint64],
-    reward: [[V.optional(R.hexString)]]
+    reward: V.optional([[R.hexString]])
+}
+
+const priorityFeeSuggestionScheme: V.Scheme<Connex.Thor.PriorityFeeSuggestion> = {
+    maxPriorityFeePerGas: R.hexString
 }

--- a/packages/framework/src/driver-guard.ts
+++ b/packages/framework/src/driver-guard.ts
@@ -11,10 +11,10 @@ export function newDriverGuard(
             V.validate(obj, scheme, path)
         } catch (err) {
             if (errHandler) {
-                errHandler(err)
+                errHandler(err as Error)
             } else {
                 // tslint:disable-next-line:no-console
-                console.warn(`Connex-Driver[MALFORMED RESPONSE]: ${err.message}`)
+                console.warn(`Connex-Driver[MALFORMED RESPONSE]: ${(err as Error).message}`)
             }
         }
         return obj
@@ -91,6 +91,10 @@ export function newDriverGuard(
                     },
                     signature: v => R.isHexBytes(v, 65) ? '' : 'expected 65 bytes'
                 }, 'signCert()'))
+        },
+        getFees(newestBlock, blockCount) {
+            return driver.getFees(newestBlock, blockCount)
+                .then(f => f ? test(f, feeScheme, 'getFees()') : f)
         }
     }
 }
@@ -221,4 +225,10 @@ const vmOutputScheme: V.Scheme<Connex.VM.Output> = {
         recipient: R.address,
         amount: R.hexString,
     }]
+}
+
+const feeScheme: V.Scheme<Connex.Thor.Fees> = {
+    baseFeePerGas: [R.hexString],
+    gasUsedRatio: [R.uint64],
+    reward: [[V.optional(R.hexString)]]
 }

--- a/packages/framework/src/driver-interface.ts
+++ b/packages/framework/src/driver-interface.ts
@@ -26,7 +26,7 @@ declare namespace Connex {
         filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
 
         getFees(newestBlock: string | number, blockCount: number): Promise<Thor.Fees | null>
-        getPriorityFeeSuggestion(): Promise<string | null>
+        getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null>
     }
 
     namespace Driver {

--- a/packages/framework/src/driver-interface.ts
+++ b/packages/framework/src/driver-interface.ts
@@ -24,6 +24,8 @@ declare namespace Connex {
 
         filterEventLogs(arg: Driver.FilterEventLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'event'>[]>
         filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
+
+        getFees(newestBlock: string | number, blockCount: number): Promise<Thor.Fees | null>
     }
 
     namespace Driver {

--- a/packages/framework/src/driver-interface.ts
+++ b/packages/framework/src/driver-interface.ts
@@ -25,7 +25,7 @@ declare namespace Connex {
         filterEventLogs(arg: Driver.FilterEventLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'event'>[]>
         filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
 
-        getFees(newestBlock: string | number, blockCount: number): Promise<Thor.Fees | null>
+        getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Thor.Fees | null>
         getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null>
     }
 

--- a/packages/framework/src/driver-interface.ts
+++ b/packages/framework/src/driver-interface.ts
@@ -26,6 +26,7 @@ declare namespace Connex {
         filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
 
         getFees(newestBlock: string | number, blockCount: number): Promise<Thor.Fees | null>
+        getPriorityFeeSuggestion(): Promise<string | null>
     }
 
     namespace Driver {

--- a/packages/framework/src/driver-interface.ts
+++ b/packages/framework/src/driver-interface.ts
@@ -26,7 +26,7 @@ declare namespace Connex {
         filterTransferLogs(arg: Driver.FilterTransferLogsArg, cacheHints?: string[]): Promise<Thor.Filter.Row<'transfer'>[]>
 
         getFees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Promise<Thor.Fees | null>
-        getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion | null>
+        getPriorityFeeSuggestion(): Promise<Connex.Thor.PriorityFeeSuggestion>
     }
 
     namespace Driver {

--- a/packages/framework/src/fees-visitor.ts
+++ b/packages/framework/src/fees-visitor.ts
@@ -1,12 +1,14 @@
 export function newFeesVisitor(
     driver: Connex.Driver,
     newestBlock: string | number,
-    blockCount: number
+    blockCount: number,
+    rewardPercentiles?: number[]
 ): Connex.Thor.Fees.Visitor {
 
     return {
         get newestBlock() { return newestBlock },
         get blockCount() { return blockCount },
-        get: () => driver.getFees(newestBlock, blockCount)
+        get rewardPercentiles() { return rewardPercentiles },
+        get: () => driver.getFees(newestBlock, blockCount, rewardPercentiles)
     }
 }

--- a/packages/framework/src/fees-visitor.ts
+++ b/packages/framework/src/fees-visitor.ts
@@ -1,0 +1,12 @@
+export function newFeesVisitor(
+    driver: Connex.Driver,
+    newestBlock: string | number,
+    blockCount: number
+): Connex.Thor.Fees.Visitor {
+
+    return {
+        get newestBlock() { return newestBlock },
+        get blockCount() { return blockCount },
+        get: () => driver.getFees(newestBlock, blockCount)
+    }
+}

--- a/packages/framework/src/thor.ts
+++ b/packages/framework/src/thor.ts
@@ -95,6 +95,9 @@ export function newThor(driver: Connex.Driver): Connex.Thor {
             }
 
             return newFeesVisitor(driver, newestBlock, blockCount)
+        },
+        priorityFeeSuggestion: () => {
+            return driver.getPriorityFeeSuggestion()
         }
     }
 }

--- a/packages/framework/src/thor.ts
+++ b/packages/framework/src/thor.ts
@@ -79,7 +79,7 @@ export function newThor(driver: Connex.Driver): Connex.Thor {
             R.test(clauses, [clauseScheme], 'arg0')
             return newExplainer(readyDriver, clauses)
         },
-        fees: (newestBlock, blockCount) => {
+        fees: (newestBlock, blockCount, rewardPercentiles) => {
             if (typeof newestBlock === 'undefined') {
                 newestBlock = driver.head.id
             } else {
@@ -91,10 +91,16 @@ export function newThor(driver: Connex.Driver): Connex.Thor {
                 blockCount = 1
             } else {
                 R.ensure(R.isUInt(blockCount, 32),
-                    'arg0: expected unsigned 32-bit integer')
+                    'arg1: expected unsigned 32-bit integer')
             }
 
-            return newFeesVisitor(driver, newestBlock, blockCount)
+            if (typeof rewardPercentiles === 'undefined') {
+                rewardPercentiles = []
+            } else {
+                R.ensure(Array.isArray(rewardPercentiles) && rewardPercentiles.every(rewardPercentile => R.isUInt(rewardPercentile, 32)),
+                    'arg2: expected an array of unsigned 32-bit integers')
+            }
+            return newFeesVisitor(driver, newestBlock, blockCount, rewardPercentiles)
         },
         priorityFeeSuggestion: () => {
             return driver.getPriorityFeeSuggestion()

--- a/packages/framework/src/thor.ts
+++ b/packages/framework/src/thor.ts
@@ -1,11 +1,12 @@
+import * as V from 'validator-ts'
 import { newAccountVisitor } from './account-visitor'
 import { newBlockVisitor } from './block-visitor'
-import { newTxVisitor } from './tx-visitor'
+import { newExplainer } from './explainer'
+import { newFeesVisitor } from './fees-visitor'
 import { newFilter } from './filter'
 import { newHeadTracker } from './head-tracker'
-import { newExplainer } from './explainer'
 import * as R from './rules'
-import * as V from 'validator-ts'
+import { newTxVisitor } from './tx-visitor'
 
 export function newThor(driver: Connex.Driver): Connex.Thor {
     const headTracker = newHeadTracker(driver)
@@ -77,6 +78,23 @@ export function newThor(driver: Connex.Driver): Connex.Thor {
         explain: (clauses) => {
             R.test(clauses, [clauseScheme], 'arg0')
             return newExplainer(readyDriver, clauses)
+        },
+        fees: (newestBlock, blockCount) => {
+            if (typeof newestBlock === 'undefined') {
+                newestBlock = driver.head.id
+            } else {
+                R.ensure(typeof newestBlock === 'string' ? R.isHexBytes(newestBlock, 32) : R.isUInt(newestBlock, 32),
+                    'arg0: expected bytes32 or unsigned 32-bit integer')
+            }
+
+            if (typeof blockCount === 'undefined') {
+                blockCount = 1
+            } else {
+                R.ensure(R.isUInt(blockCount, 32),
+                    'arg0: expected unsigned 32-bit integer')
+            }
+
+            return newFeesVisitor(driver, newestBlock, blockCount)
         }
     }
 }

--- a/packages/types/fees.d.ts
+++ b/packages/types/fees.d.ts
@@ -19,6 +19,9 @@ declare namespace Connex.Thor {
 
             readonly blockCount: number
 
+            /** array of reward percentiles to query */
+            readonly rewardPercentiles?: number[]
+
             /** query the fees */
             get(): Promise<Fees | null>
         }

--- a/packages/types/fees.d.ts
+++ b/packages/types/fees.d.ts
@@ -1,0 +1,21 @@
+declare namespace Connex.Thor {
+    /** the fees model */
+    type Fees = {
+        baseFeePerGas: string[]
+        gasUsedRatio: number[]
+        reward?: string[][]
+    }
+
+    namespace Fees {
+        /** the block visitor interface */
+        interface Visitor {
+            /** id or number of the fees to be visited */
+            readonly newestBlock: string | number
+
+            readonly blockCount: number
+
+            /** query the fees */
+            get(): Promise<Fees | null>
+        }
+    }
+}

--- a/packages/types/fees.d.ts
+++ b/packages/types/fees.d.ts
@@ -1,6 +1,7 @@
 declare namespace Connex.Thor {
     /** the fees model */
     type Fees = {
+        oldestBlock: string
         baseFeePerGas: string[]
         gasUsedRatio: number[]
         reward?: string[][]

--- a/packages/types/fees.d.ts
+++ b/packages/types/fees.d.ts
@@ -6,6 +6,10 @@ declare namespace Connex.Thor {
         reward?: string[][]
     }
 
+    type PriorityFeeSuggestion = {
+        maxPriorityFeePerGas: string
+    }
+
     namespace Fees {
         /** the block visitor interface */
         interface Visitor {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -3,6 +3,7 @@
 /// <reference path="vm.d.ts" />
 /// <reference path="account.d.ts" />
 /// <reference path="block.d.ts" />
+/// <reference path="fees.d.ts" />
 /// <reference path="tx.d.ts" />
 /// <reference path="filter.d.ts" />
 /// <reference path="signer.d.ts" />

--- a/packages/types/thor.d.ts
+++ b/packages/types/thor.d.ts
@@ -42,6 +42,11 @@ declare namespace Connex {
          * @param blockCount number of blocks to query
          */
         fees(newestBlock: string | number, blockCount: number): Thor.Fees.Visitor
+
+        /**
+         * get a priority fee suggestion
+         */
+        priorityFeeSuggestion(): Promise<Thor.PriorityFeeSuggestion | null>
     }
 
     namespace Thor {

--- a/packages/types/thor.d.ts
+++ b/packages/types/thor.d.ts
@@ -35,6 +35,13 @@ declare namespace Connex {
 
         /** create an explainer to simulate tx execution */
         explain(clauses: VM.Clause[]): VM.Explainer
+
+        /**
+         * create a visitor to the fees specified by the given revision
+         * @param newestBlock block id or number
+         * @param blockCount number of blocks to query
+         */
+        fees(newestBlock: string | number, blockCount: number): Thor.Fees.Visitor
     }
 
     namespace Thor {

--- a/packages/types/thor.d.ts
+++ b/packages/types/thor.d.ts
@@ -40,8 +40,9 @@ declare namespace Connex {
          * create a visitor to the fees specified by the given revision
          * @param newestBlock block id or number
          * @param blockCount number of blocks to query
+         * @param rewardPercentiles array of reward percentiles to query
          */
-        fees(newestBlock: string | number, blockCount: number): Thor.Fees.Visitor
+        fees(newestBlock: string | number, blockCount: number, rewardPercentiles?: number[]): Thor.Fees.Visitor
 
         /**
          * get a priority fee suggestion


### PR DESCRIPTION
Tested with the REPL package:

```
➜  repl git:(feat/fees-support) node dist/index.js https://galactica.dev.node.vechain.org/
VeChain Connex Playground v2.1.1 @ https://galactica.dev.node.vechain.org/
framework v2.1.1
Custom(100%)> await thor.priorityFeeSuggestion()
{ maxPriorityFeePerGas: '0x1b385e75f97' }
Custom(100%)> await thor.fees('0x000061a2f11d81ca015b7733e9ac106812e29733067d4d85395126bac3985a91',2, [25,50,75]).get()
{
  oldestBlock: '0x000061a17b2bef025f9c8253b415d34bda19a81f0e8daf35e4354d60b910632c',
  baseFeePerGas: [ '0x1e4c77f85ecf', '0x1f69f2c42932' ],
  gasUsedRatio: [ 0.9708322, 0.9943652 ],
  reward: [ [ '0x7b', '0xfc', '0x164' ], [ '0x60', '0xee', '0x155' ] ]
}
Custom(100%)> 
```